### PR TITLE
Changed phpdoc of hydrate method with generics

### DIFF
--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -14,14 +14,17 @@ class Hydrator
     private $reflectionClassMap;
 
     /**
-     * @param string|object $target
+     * @template T
+     * @param class-string<T> $target
      * @param array $data
-     * @return object
+     * @return T
      * @throws \ReflectionException
      */
     public function hydrate($target, array $data)
     {
         $reflection = $this->getReflectionClass($target);
+
+        /** @var T $object */
         $object = is_object($target) ? $target : $reflection->newInstanceWithoutConstructor();
 
         foreach ($data as $name => $value) {


### PR DESCRIPTION
Phpstorm and phpstan show an error like `Return value is expected to be '\App\Feature', 'object' returned` if we immediately return the hydration result from the method and at the same time explicitly expect that `\App\Feature` will return like `protected function ololo(): \App\Feature`. In my case, generics solved it